### PR TITLE
Stricter permissions for AJAX callbacks

### DIFF
--- a/ddb_cp.module
+++ b/ddb_cp.module
@@ -64,31 +64,31 @@ function ddb_cp_menu() {
   $items['admin/ddb_cp/test/xml'] = array(
     'page callback' => 'ddb_cp_get_test_result',
     'type' => MENU_CALLBACK,
-    'access arguments' => array('access content'),
+    'access arguments' => array('administer ddb_cp''),
   );
 
   $items['ajax/ddb_cp/status'] = array(
     'page callback' => 'ddb_cp_ajax_status',
     'type' => MENU_CALLBACK,
-    'access arguments' => array('access content'),
+    'access arguments' => array('administer ddb_cp''),
   );
 
   $items['ajax/ddb_cp/test/execute'] = array(
     'page callback' => 'ddb_cp_ajax_test_execute',
     'type' => MENU_CALLBACK,
-    'access arguments' => array('access content'),
+    'access arguments' => array('administer ddb_cp''),
   );
 
   $items['ajax/ddb_cp/recreate'] = array(
     'page callback' => 'ddb_cp_ajax_recreate',
     'type' => MENU_CALLBACK,
-    'access arguments' => array('access content'),
+    'access arguments' => array('administer ddb_cp''),
   );
 
   $items['ajax/ddb_cp/test/result'] = array(
     'page callback' => 'ddb_cp_ajax_test_result',
     'type' => MENU_CALLBACK,
-    'access arguments' => array('access content'),
+    'access arguments' => array('administer ddb_cp''),
   );
 
   return $items;


### PR DESCRIPTION
Ajax callbacks currently require the `access content` permission. That permissions does not seem to be strict enough compared to who is supposed to use them and what the callbacks actually do.

I suggest that the permission is changed to `administer ddb_cp` which is also used for the form where the callbacks are intended to be used.
